### PR TITLE
handling visually hidden content

### DIFF
--- a/components/Navbar.jsx
+++ b/components/Navbar.jsx
@@ -107,7 +107,7 @@ const Navbar = (user_role) => {
           <div></div>
           <div></div>
         </div>
-        <div className={`${navActive ? 'active' : ''} nav__menu-list`}>
+        <div className={`${navActive ? 'active' : 'hide'} nav__menu-list`}>
           {MENU_LIST.map((menu, idx) => {
             if (menu.sessionRequired && !session) {
               return;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -403,6 +403,13 @@ footer a {
   } 
 }
 
+/* Logic to hide nav bar elements when navbar is not active */
+@media screen and (max-width: 768px) {
+  .hide{
+    display: none;
+  }
+}
+
 @media screen and (min-width: 768px) {
   .nav__menu-bar {
     display: none;


### PR DESCRIPTION
- Hide nav items from DOM on collapse state of hamburger menu

- Elements should be rendered by screen reader only when hamburger menu is expanded



























