### PR TITLE
Fixing default Country option for India

### DIFF
--- a/pages/studentregistration.jsx
+++ b/pages/studentregistration.jsx
@@ -265,7 +265,11 @@ export default function Page() {
   const updateCountriesOptions = () => {
     const countries = [];
     worldData.map(country => {
-      countries.push(<option value={country.name}>{country.name}</option>);
+      if (country.name == 'India') {
+        countries.push(<option selected value={country.name}>{country.name}</option>);
+      } else {
+        countries.push(<option value={country.name}>{country.name}</option>);
+      }
     });
     setCountriesOptions(countries);
   }
@@ -282,6 +286,7 @@ export default function Page() {
 
   useEffect(() => {
     updateCountriesOptions();
+    updateStateOptions({target:{value:'India'}});
   }, []);
 
 
@@ -618,7 +623,7 @@ export default function Page() {
                               required
                               role="presentation"
                             >
-                              <option value="India">India</option>
+                              <option></option>
                               {countriesOptions}
                             </select>
                           </td>


### PR DESCRIPTION
Setting the default option wasn't as simple as I had hoped because of React.

This change should now load in the countries and apply `selected` to the "India" option and also fetch the states in India after to hydrate the State dropdown.